### PR TITLE
Increase AMI creation timeout

### DIFF
--- a/resources/index.py
+++ b/resources/index.py
@@ -129,7 +129,7 @@ def create_ami(
     check_ami_count = 0
     while check_ami(image_id) != "available":
         check_ami_count += 1
-        if check_ami_count == 30:
+        if check_ami_count == 45:
             raise RuntimeError("AMI did not become available")
         time.sleep(15)
 


### PR DESCRIPTION
On most runs my AMI fails to create within the 7.5 min ( time.sleep * check_ami_count ) timeout window. Propose increasing check_ami_count to 45
